### PR TITLE
1.18.2 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "0.10-SNAPSHOT"
+    id "fabric-loom" version "0.11-SNAPSHOT"
     id "maven-publish"
     id "org.ajoberstar.grgit" version "4.1.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.18.2+build.3
 loader_version=0.13.3
 
 # Mod Properties
-mod_version=0.3.0
+mod_version=0.2.0
 maven_group=dev.kir
 archives_base_name=smart-recipes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.18
-yarn_mappings=1.18+build.1
-loader_version=0.12.12
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.3
+loader_version=0.13.3
 
 # Mod Properties
-mod_version=0.2.0
+mod_version=0.3.0
 maven_group=dev.kir
 archives_base_name=smart-recipes
 
 # Dependencies
-fabric_version=0.44.0+1.18
+fabric_version=0.51.0+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ maven_group=dev.kir
 archives_base_name=smart-recipes
 
 # Dependencies
-fabric_version=0.51.0+1.18.2
+fabric_version=0.47.8+1.18.2

--- a/src/main/java/dev/kir/smartrecipes/api/RecipeConditions.java
+++ b/src/main/java/dev/kir/smartrecipes/api/RecipeConditions.java
@@ -18,12 +18,13 @@ import net.minecraft.world.WorldProperties;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 final class RecipeConditions {
     public static final RegistryKey<Registry<RecipeCondition>> KEY = RegistryKey.ofRegistry(new Identifier("recipe_condition"));
-    public static final Registry<RecipeCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental());
+    public static final Registry<RecipeCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), (Function)null);
 
 
     public static final RecipeCondition FALSE = (e, i) -> false;

--- a/src/main/java/dev/kir/smartrecipes/api/RecipeConditions.java
+++ b/src/main/java/dev/kir/smartrecipes/api/RecipeConditions.java
@@ -18,13 +18,12 @@ import net.minecraft.world.WorldProperties;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 final class RecipeConditions {
     public static final RegistryKey<Registry<RecipeCondition>> KEY = RegistryKey.ofRegistry(new Identifier("recipe_condition"));
-    public static final Registry<RecipeCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), (Function)null);
+    public static final Registry<RecipeCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), null);
 
 
     public static final RecipeCondition FALSE = (e, i) -> false;

--- a/src/main/java/dev/kir/smartrecipes/api/RecipeReloadConditions.java
+++ b/src/main/java/dev/kir/smartrecipes/api/RecipeReloadConditions.java
@@ -13,11 +13,10 @@ import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.util.registry.SimpleRegistry;
 
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 final class RecipeReloadConditions {
     public static final RegistryKey<Registry<RecipeReloadCondition>> KEY = RegistryKey.ofRegistry(new Identifier("recipe_reload_condition"));
-    public static final Registry<RecipeReloadCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), (Function)null);
+    public static final Registry<RecipeReloadCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), null);
 
 
     public static final RecipeReloadCondition END_DATA_PACK_RELOAD = create(ServerLifecycleEvents.END_DATA_PACK_RELOAD, ServerLifecycleEvents.SERVER_STARTED, (e, c) -> e.register((s, __, ___) -> c.invoker().onRecipeReloadEvent(s, c.getId())), (e, c) -> e.register(s -> c.invoker().onRecipeReloadEvent(s, c.getId())));

--- a/src/main/java/dev/kir/smartrecipes/api/RecipeReloadConditions.java
+++ b/src/main/java/dev/kir/smartrecipes/api/RecipeReloadConditions.java
@@ -13,10 +13,11 @@ import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.util.registry.SimpleRegistry;
 
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 final class RecipeReloadConditions {
     public static final RegistryKey<Registry<RecipeReloadCondition>> KEY = RegistryKey.ofRegistry(new Identifier("recipe_reload_condition"));
-    public static final Registry<RecipeReloadCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental());
+    public static final Registry<RecipeReloadCondition> REGISTRY = new SimpleRegistry<>(KEY, Lifecycle.experimental(), (Function)null);
 
 
     public static final RecipeReloadCondition END_DATA_PACK_RELOAD = create(ServerLifecycleEvents.END_DATA_PACK_RELOAD, ServerLifecycleEvents.SERVER_STARTED, (e, c) -> e.register((s, __, ___) -> c.invoker().onRecipeReloadEvent(s, c.getId())), (e, c) -> e.register(s -> c.invoker().onRecipeReloadEvent(s, c.getId())));

--- a/src/main/java/dev/kir/smartrecipes/mixin/MinecraftServerMixin.java
+++ b/src/main/java/dev/kir/smartrecipes/mixin/MinecraftServerMixin.java
@@ -5,15 +5,15 @@ import com.mojang.authlib.minecraft.MinecraftSessionService;
 import com.mojang.datafixers.DataFixer;
 import dev.kir.smartrecipes.api.event.ServerStateEvents;
 import net.minecraft.resource.ResourcePackManager;
-import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.SaveLoader;
 import net.minecraft.server.WorldGenerationProgressListenerFactory;
 import net.minecraft.util.UserCache;
-import net.minecraft.util.registry.DynamicRegistryManager;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.SaveProperties;
 import net.minecraft.world.level.storage.LevelStorage;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -38,7 +38,7 @@ abstract class MinecraftServerMixin {
     private GameMode gameMode;
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void init(Thread serverThread, DynamicRegistryManager.Impl registryManager, LevelStorage.Session session, SaveProperties saveProperties, ResourcePackManager dataPackManager, Proxy proxy, DataFixer dataFixer, ServerResourceManager serverResourceManager, MinecraftSessionService sessionService, GameProfileRepository gameProfileRepo, UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory, CallbackInfo ci) {
+    private void init(Thread serverThread, LevelStorage.Session session, ResourcePackManager dataPackManager, SaveLoader saveLoader, Proxy proxy, DataFixer dataFixer, @Nullable MinecraftSessionService sessionService, @Nullable GameProfileRepository gameProfileRepo, @Nullable UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory, CallbackInfo ci) {
         this.difficulty = saveProperties.getDifficulty();
         this.gameMode = saveProperties.getGameMode();
     }

--- a/src/main/java/dev/kir/smartrecipes/mixin/ServerWorldMixin.java
+++ b/src/main/java/dev/kir/smartrecipes/mixin/ServerWorldMixin.java
@@ -6,14 +6,15 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.WorldGenerationProgressListener;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.profiler.Profiler;
+import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.MutableWorldProperties;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
-import net.minecraft.world.gen.Spawner;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.level.ServerWorldProperties;
 import net.minecraft.world.level.storage.LevelStorage;
+import net.minecraft.world.spawner.Spawner;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -42,12 +43,12 @@ abstract class ServerWorldMixin extends World {
     @Unique
     private TimeOfDay timeOfDay;
 
-    private ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, DimensionType dimensionType, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed) {
+    private ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, RegistryEntry<DimensionType> dimensionType, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long seed) {
         super(properties, registryRef, dimensionType, profiler, isClient, debugWorld, seed);
     }
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void init(MinecraftServer server, Executor workerExecutor, LevelStorage.Session session, ServerWorldProperties properties, RegistryKey<World> worldKey, DimensionType dimensionType, WorldGenerationProgressListener worldGenerationProgressListener, ChunkGenerator chunkGenerator, boolean debugWorld, long seed, List<Spawner> spawners, boolean shouldTickTime, CallbackInfo ci) {
+    private void init(MinecraftServer server, Executor workerExecutor, LevelStorage.Session session, ServerWorldProperties properties, RegistryKey<World> worldKey, RegistryEntry<DimensionType> registryEntry, WorldGenerationProgressListener worldGenerationProgressListener, ChunkGenerator chunkGenerator, boolean debugWorld, long seed, List<Spawner> spawners, boolean shouldTickTime, CallbackInfo ci) {
         this.wasRaining = properties.isRaining();
         this.wasThundering = properties.isThundering();
         this.timeOfDay = TimeOfDay.fromTime(properties.getTimeOfDay());


### PR DESCRIPTION
Quick port to 1.18.2. Mostly mixin fixes and version bumps. Tested with sync, which seems to work fine (the crafting recipe changes in hardcore) on the surface. Might benefit from some more rigorous testing.